### PR TITLE
Update dark.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # DarkCloud: Soundcloud Night Mode
 Browser extension that changes soundcloud.com to a dark theme.
 
-Available for <a href="https://addons.mozilla.org/en-US/firefox/addon/darkcloud/">Firefox</a> and <a href="https://addons.opera.com/en-gb/extensions/details/darkcloud/">Opera</a>.<br>
-For Chrome download/install and more info, go <a href="http://deathgrips.dx.am/darkcloud.php">here</a>.
+This github repo is a fixed version of "DarkCloud".

--- a/dark.css
+++ b/dark.css
@@ -10,11 +10,11 @@ a:hover {
 	color: #eee !important;
 }
 
-.commentItem__body {
+.commentItem__body,  .commentItem__username {
     color: #eee;
 }
 
-.commentItem__timestampLink, .commentItem__timestampLink:hover, .commentItem__timestampLink:visited {
+.commentItem__timestampLink{
     background-color: grey;
 }
 
@@ -65,7 +65,7 @@ a:hover {
 
 /* menu buttons */
 
-.sc-button-medium.sc-button-more::before, .sc-button-medium.sc-button-copylink::before, .sc-button-medium.sc-button-share::before, .sc-button-medium.sc-button-repost::before, .sc-button-medium.sc-button-like::before, .sc-classic .repeatControl.m-none, .sc-classic .shuffleControl::before, .sc-classic .skipControl__next, .sc-classic .playControl.playing, .sc-classic .playControl, .sc-classic .skipControl__previous, .sc-classic .volume[data-level="6"] .volume__button, .sc-classic .volume[data-level="7"] .volume__button, .sc-classic .volume[data-level="8"] .volume__button, .sc-classic .volume[data-level="9"] .volume__button, .sc-classic .volume[data-level="10"] .volume__button, .sc-classic .volume.muted .volume__button, .sc-classic .volume[data-level="1"] .volume__button, .sc-classic .volume[data-level="2"] .volume__button, .sc-classic .volume[data-level="3"] .volume__button, .sc-classic .volume[data-level="4"] .volume__button, .sc-classic .volume[data-level="5"] .volume__button {
+.sc-button-medium.sc-button-more::before, .sc-button-medium.sc-button-copylink::before, .sc-button-medium.sc-button-share::before, .sc-button-medium.sc-button-repost::before, .sc-button-medium.sc-button-like::before, .sc-classic .repeatControl.m-none, .sc-classic .shuffleControl::before, .sc-classic .skipControl__next, .sc-classic .playControl.playing, .sc-classic .playControl, .sc-classic .skipControl__previous, .sc-classic .volume[data-level="6"] .volume__button, .sc-classic .volume[data-level="7"] .volume__button, .sc-classic .volume[data-level="8"] .volume__button, .sc-classic .volume[data-level="9"] .volume__button, .sc-classic .volume[data-level="10"] .volume__button, .sc-classic .volume.muted .volume__button, .sc-classic .volume[data-level="1"] .volume__button, .sc-classic .volume[data-level="2"] .volume__button, .sc-classic .volume[data-level="3"] .volume__button, .sc-classic .volume[data-level="4"] .volume__button, .sc-classic .volume[data-level="5"] .volume__button, .sc-button-medium.sc-button-delete::before {
     filter: brightness(300%);
 }
 

--- a/dark.css
+++ b/dark.css
@@ -59,9 +59,13 @@ a:hover {
     border-bottom: 1px solid #313131
 }
 
+.sc-classic .playControls__bg, .sc-classic .playControls__inner {
+    border: unset;
+}
+
 /* menu buttons */
 
-.sc-button-medium.sc-button-more::before, .sc-button-medium.sc-button-copylink::before, .sc-button-medium.sc-button-share::before, .sc-button-medium.sc-button-repost::before, .sc-button-medium.sc-button-like::before  {
+.sc-button-medium.sc-button-more::before, .sc-button-medium.sc-button-copylink::before, .sc-button-medium.sc-button-share::before, .sc-button-medium.sc-button-repost::before, .sc-button-medium.sc-button-like::before, .sc-classic .repeatControl.m-none, .sc-classic .shuffleControl::before, .sc-classic .skipControl__next, .sc-classic .playControl.playing, .sc-classic .playControl, .sc-classic .skipControl__previous, .sc-classic .volume[data-level="6"] .volume__button, .sc-classic .volume[data-level="7"] .volume__button, .sc-classic .volume[data-level="8"] .volume__button, .sc-classic .volume[data-level="9"] .volume__button, .sc-classic .volume[data-level="10"] .volume__button, .sc-classic .volume.muted .volume__button, .sc-classic .volume[data-level="1"] .volume__button, .sc-classic .volume[data-level="2"] .volume__button, .sc-classic .volume[data-level="3"] .volume__button, .sc-classic .volume[data-level="4"] .volume__button, .sc-classic .volume[data-level="5"] .volume__button {
     filter: brightness(300%);
 }
 

--- a/dark.css
+++ b/dark.css
@@ -10,6 +10,67 @@ a:hover {
 	color: #eee !important;
 }
 
+.commentItem__body {
+    color: #eee;
+}
+
+.commentItem__timestampLink, .commentItem__timestampLink:hover, .commentItem__timestampLink:visited {
+    background-color: grey;
+}
+
+.sc-classic .l-listen-wrapper, .l-about-rows, .sc-border-light-right {
+    border-right: 1px solid #313131;
+}
+
+.sc-classic .l-listen-wrapper .l-about-rows {
+    border-right: 1px solid #313131;
+}
+
+.sc-classic .g-tabs {
+    border-bottom: unset;
+}
+
+.sc-border-light-top {
+    border-top: unset;
+}
+
+.sc-classic .g-tabs-link, .sc-classic .g-tabs-link:visited {
+    border-bottom: unset;
+}
+
+.sc-classic .listenEngagement {
+    box-shadow: unset;
+}
+
+.sc-classic .commentForm__input {
+    border: 1px solid #313131;
+}
+
+.commentForm__wrapper {
+    border: #888 !important
+}
+
+.sc-classic .gritter-item-wrapper {
+    background-color: black;
+    border: unset;
+}
+
+.sc-classic .mixedSelectionModule {
+    border-bottom: 1px solid #313131
+}
+
+/* menu buttons */
+
+.sc-button-medium.sc-button-more::before, .sc-button-medium.sc-button-copylink::before, .sc-button-medium.sc-button-share::before, .sc-button-medium.sc-button-repost::before, .sc-button-medium.sc-button-like::before  {
+    filter: brightness(300%);
+}
+
+.sc-button-active.sc-button-medium.sc-button-more::before, .sc-button-selected.sc-button-medium.sc-button-more::before, .sc-button-selected.sc-button-medium.sc-button-repost::before, .sc-button-selected.sc-button-medium.sc-button-like:active::before, .sc-button-selected.sc-button-medium.sc-button-like:focus::before, .sc-button-selected.sc-button-medium.sc-button-like::before {
+    filter: brightness(100%);
+}
+
+/* end of menu buttons */
+
 .banner {
 	background: #000 !important;
 	color: #888 !important;


### PR DESCRIPTION
updated to newest version of soundcloud website; lines 13-19
the newest version of soundcloud website included comment changes. these comments changes aren't covered by darkcloud and instead comment text will appear as black text

before:

![19595](https://github.com/IEVEVO/darkcloud/assets/107429396/61bd48d6-a807-4f7d-a004-a1955f0457ed)

updated:

![image](https://github.com/IEVEVO/darkcloud/assets/107429396/c9a98479-6b1f-41e8-9b12-c12284672386)

also added some quality of life changes that should adapt to the dark mode a bit more (i.e. made borders a bit more greyer, removed some borders, made a few icons lighter, and etc)