### PR TITLE
Update dark.css

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -4,7 +4,7 @@ body {
 }
 
 a, a:visited, .sc-link-dark, .soundContext__usernameLink, .localeSelector__cancel, .localeSelectorContent__listItem, .sc-font {
-	color: #ddd !important;
+	color: #38d; !important;
 }
 a:hover {
 	color: #eee !important;
@@ -540,5 +540,73 @@ kbd.sc-font {
 
 .commentItem__body, .commentItem__replyButton, .commentItem__usernameLink {
 	color: #fff !important; /*Fixed black text in comments to white*/
+}
 
-} 
+.artistShortcutTile__username span {
+	color: #fff !important; /*Correction of the artist's name on the homepage*/
+}
+
+.sc-button-selected.sc-button-medium.sc-button-like:before { 
+	filter: invert(0%) !important;
+}
+
+.sc-button-medium.sc-button-like:before{
+	filter: invert(100%) !important;
+}
+
+.sc-button-small.sc-button-like:before{
+	filter: invert(100%) !important;
+}
+
+.sc-button-small.sc-button-selected.sc-button-like:before, .sc-button-small.sc-button-selected.sc-button-like.sc-button-lightfg:before, .sc-button-small.sc-button-selected.sc-button-like.sc-button-visual:before{
+	filter: invert(0%) !important; /*Correction of the like icon so that it is more visible*/
+}
+
+.sc-classic .playbackSoundBadge__titleLink, .sc-classic .playbackSoundBadge__titleLink:visited {
+	color: #fff !important;
+}
+
+.playbackSoundBadge__showQueue{
+	filter: invert(100%) !important; /*Correction of the queue icon so that it is more visible*/
+}
+
+.localeSelector_language{
+	color: #f50 !important;
+}
+
+.sc-classic .playableTile__mainHeading{
+	font-size: 14px;
+}
+  .sc-classic .playableTile__heading{
+	line-height: 1.4;
+}
+  a.sc-link-dark{
+	filter: invert(100%) !important;
+}
+  a.sc-link-dark, a:hover{
+	color: #333;
+}
+  .playableTile__heading{
+	width: 100%;
+	display: block;
+}
+  .sc-type-light{
+	font-weight: 100;
+	color: #999;
+}
+  .sc-truncate{
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	word-break: normal;
+}
+  .sc-font-light{
+	font-weight: 100;
+}
+  .sc-font, .sc-font-light{
+	font-family: Inter,sans-serif;
+}
+  a, a:visited{
+	color: #38d;
+	text-decoration: none; /*Color correction of the titles and the artist on the homepage*/
+}


### PR DESCRIPTION
Correction of many small details: 

- Fixed the like icon which was dimmed; it is now more visible and more attractive.
- Corrected the names of artists in the 'Artists you should follow' category which were dimmed; they are now more visible.
- Fixed the queue icon which was dimmed; it is now more visible.
- Corrected the colors of the titles and artists; previously, the whole page was the same color, and now we can differentiate between the artist and the title.
- Fixed the color of the language text, which was slightly dimmed; I changed it to blue for 'language' and orange for the selected language.